### PR TITLE
created struct AudioRecording under 'Models/AudioRecording.swift', mo…

### DIFF
--- a/visualizer.xcodeproj/project.pbxproj
+++ b/visualizer.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		8EEFAF9127130F8000E3651D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8EEFAF9027130F8000E3651D /* Assets.xcassets */; };
 		8EEFAF9427130F8000E3651D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8EEFAF9327130F8000E3651D /* Preview Assets.xcassets */; };
 		B0624A6A286C3C80005849F0 /* DisplayDrawerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0624A69286C3C80005849F0 /* DisplayDrawerButton.swift */; };
+		B0713B7C28767B4F00C0A370 /* AudioRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0713B7B28767B4E00C0A370 /* AudioRecording.swift */; };
 		B0C5D29F2875264C00CDC7CC /* DisplayDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C5D29E2875264C00CDC7CC /* DisplayDrawer.swift */; };
 		B0D97864286D4249003880F2 /* DisplayDrawerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D97863286D4249003880F2 /* DisplayDrawerViewModel.swift */; };
 		B0D97866286D4290003880F2 /* DisplayDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D97865286D4290003880F2 /* DisplayDrawerView.swift */; };
@@ -237,6 +238,7 @@
 		8EEFAF9327130F8000E3651D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		8EEFAFA12713146200E3651D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B0624A69286C3C80005849F0 /* DisplayDrawerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayDrawerButton.swift; sourceTree = "<group>"; };
+		B0713B7B28767B4E00C0A370 /* AudioRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecording.swift; sourceTree = "<group>"; };
 		B0C5D29E2875264C00CDC7CC /* DisplayDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayDrawer.swift; sourceTree = "<group>"; };
 		B0D97863286D4249003880F2 /* DisplayDrawerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayDrawerViewModel.swift; sourceTree = "<group>"; };
 		B0D97865286D4290003880F2 /* DisplayDrawerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayDrawerView.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 				491041D027ADB32100196A2D /* Audio.swift */,
 				8E09213727BB803A00F540B6 /* TimbreDrawer.swift */,
 				B0C5D29E2875264C00CDC7CC /* DisplayDrawer.swift */,
+				B0713B7B28767B4E00C0A370 /* AudioRecording.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1033,6 +1036,7 @@
 				498F0BED274F808B00A46486 /* MoreButton.swift in Sources */,
 				498F0BF1274F909600A46486 /* DismissButton.swift in Sources */,
 				49DECB11273A730D00C992CE /* Typography.swift in Sources */,
+				B0713B7C28767B4F00C0A370 /* AudioRecording.swift in Sources */,
 				499451F827F471B000CB9BD0 /* AudioFeaturesDrawerView.swift in Sources */,
 				8E63BE2527B29DB6007735DF /* Harmonics.swift in Sources */,
 				8EEFAF8D27130F7E00E3651D /* visualizerApp.swift in Sources */,

--- a/visualizer/Core/Audio/ViewModels/AudioViewModel.swift
+++ b/visualizer/Core/Audio/ViewModels/AudioViewModel.swift
@@ -33,7 +33,7 @@ class AudioViewModel: ObservableObject {
     
     @Published var timbreDrawerVM = TimbreDrawerViewModel()
     
-    @Published var DisplayDrawerVM = DisplayDrawerViewModel() // added 30/06/2022 John Yeung
+    @Published var DisplayDrawerVM = DisplayDrawerViewModel()
     
     @Published var isStarted: Bool = false
     
@@ -207,7 +207,8 @@ class AudioViewModel: ObservableObject {
         }
         // update the last captured amplitude
         self.audio.lastAmplitude = Double(amplitude[0])
-        
+        self.audio.recording.addAmplitude(lastAmplitude: self.audio.lastAmplitude)
+            
         self.updateReferenceTimbre()
         self.updateIsPitchAccurate()
     }
@@ -369,12 +370,16 @@ class AudioViewModel: ObservableObject {
     }
     
     func switchCaptureTime(){
-        let options:Array<Int> = [1, 3, 5, 10]
-        let i = options.firstIndex(of:self.audio.captureTime)!
-        if(i == options.count-1){
-            self.audio.captureTime = options[0]
-        }else{
-            self.audio.captureTime = options[i+1]
-        }
+//        let options:Array<Int> = [1, 3, 5, 10]
+//        let i = options.firstIndex(of:self.audio.captureTime)!
+//        if(i == options.count-1){
+//            self.audio.captureTime = options[0]
+//        }else{
+//            self.audio.captureTime = options[i+1]
+//        }
+        
+        self.audio.captureTime = 10 // fix the captured time as 10s
     }
+    
+    
 }

--- a/visualizer/Core/Audio/Views/SoundView.swift
+++ b/visualizer/Core/Audio/Views/SoundView.swift
@@ -33,7 +33,16 @@ struct SoundView: View {
                     
                     Spacer()
                     
-                    CaptureTimeButton(action: vm.switchCaptureTime,captureTime: vm.audio.captureTime)
+                    CaptureTimeButton(
+                        action: {
+                            vm.audio.recording.toggleRecording()
+                            
+                        },
+                        captureTime: vm.audio.captureTime,
+                        isRecording: vm.audio.recording.isRecording)
+//                    Text(String(vm.audio.recording.recordedAmplitude.count))
+//                    Text(String(vm.audio.recording.isRecording))
+//                    Text(String(vm.audio.recording.timeCap))
                     
                 }
                 .padding(.top, 72)

--- a/visualizer/Core/Components/Buttons/CaptureTimeButton.swift
+++ b/visualizer/Core/Components/Buttons/CaptureTimeButton.swift
@@ -10,27 +10,42 @@ import SwiftUI
 struct CaptureTimeButton: View {
     let action: () -> Void
     let captureTime: Int
+    var isRecording: Bool // sent from vm.audio.recording.isRecording
 
     var body: some View {
         Button {
             self.action()
         } label: {
-            Text("\(captureTime) s")
-                .font(.label.medium)
-                .foregroundColor(.neutral.onSurface)
-                .padding(EdgeInsets(top: 8, leading: 36, bottom: 8, trailing: 36))
-                .background(Color.neutral.surface)
-                .cornerRadius(16)
+            if (self.isRecording){
+                Image(systemName: "mic.fill")
+                    .frame(width: 96, height: 48)
+                    .foregroundColor(Color(.systemRed))
+                    .background(Color.neutral.surface)
+                    .clipShape(Rectangle())
+                    .font(.system(size: 22))
+            } else{
+                Image(systemName: "mic.fill")
+                    .frame(width: 96, height: 48)
+                    .foregroundColor(.neutral.onSurface)
+                    .background(Color.neutral.surface)
+                    .clipShape(Rectangle())
+                    .font(.system(size: 22))
+            }
         }
     }
 }
 
 struct CaptureTimeButton_Previews: PreviewProvider {
+    
     static func test() -> Void {
         print("Drawer Button Clicked")
     }
 
     static var previews: some View {
-        CaptureTimeButton(action: self.test, captureTime: 2)
+        VStack(){
+            CaptureTimeButton(action:self.test, captureTime: 10, isRecording: false)
+            CaptureTimeButton(action:self.test, captureTime: 10, isRecording: true)
+        }
+        
     }
 }

--- a/visualizer/Core/Components/Visuals/Amplitudes.swift
+++ b/visualizer/Core/Components/Visuals/Amplitudes.swift
@@ -29,7 +29,10 @@ struct Amplitudes: View {
                             if(!vm.isStarted){
                                 self.timer?.invalidate()
                             }else{
-                                self.timer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { (timer) in
+                                self.timer = Timer.scheduledTimer(
+                                    withTimeInterval: 0.05,
+                                    repeats: true)
+                                { (timer) in
                                     value = (vm.audio.lastAmplitude * 30, counter)
                                     if(counter == 10){
                                         counter = 0

--- a/visualizer/Models/Audio.swift
+++ b/visualizer/Models/Audio.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Audio {
     var amplitudes: [Double] // realtime amplitudes
     var amplitudesToDisplay: [Double] // amplitudes on change by some event(e.g., pitch change)
+    var recording: AudioRecording
     var peakBarIndex: Int
     var pitchNotation: String
     var pitchFrequency: Float
@@ -26,6 +27,7 @@ struct Audio {
     static let `default` = Audio(
         amplitudes: Array(repeating: 0.5, count: 256),
         amplitudesToDisplay: Array(repeating: 0.5, count: 256),
+        recording: AudioRecording(recordedAmplitude:[], timeCap:-1),
         peakBarIndex: -1,
         pitchNotation: "-",
         pitchFrequency: 0.0,
@@ -35,7 +37,7 @@ struct Audio {
         harmonicAmplitudes: Array(repeating: 0.5, count: 12),
         audioFeatures: AudioFeatures(spectralCentroid: 0, inharmonicity: 0, quality: 0),
         lastAmplitude: 0,
-        captureTime: 1
+        captureTime: 10 // now fixed as 10
     )
 }
 

--- a/visualizer/Models/AudioRecording.swift
+++ b/visualizer/Models/AudioRecording.swift
@@ -8,21 +8,44 @@
 
 import Foundation
 
-struct AudioRecordings {
+struct AudioRecording {
     var recordedAmplitude: Array<Double> = [] // the stored Amplitudes
     var timeCap: Int = -1 // the maximum size for the recorded amplitude, -1 means unlimited
+    var isRecording: Bool=false
     
-    mutating func addAmplitude(lastAmplitude: Double)->Bool{ // return a boolean value to var isRecording, stop the recording if recordedAmplitude reached its max size
-        if (self.timeCap > 0 && self.recordedAmplitude.count < timeCap){
-            self.recordedAmplitude.append(lastAmplitude)
-            return true
-        } else{
-            return false
+    mutating func addAmplitude(lastAmplitude: Double)->Void{ // return a boolean value to var isRecording, stop the recording if recordedAmplitude reached its max size
+        if (self.isRecording){
+            if ((self.timeCap == -1) || (self.recordedAmplitude.count < timeCap)){
+                self.recordedAmplitude.append(lastAmplitude)
+            } else{
+                self.endRecording()
+            }
+        }
+    }
+    
+    mutating func toggleRecording(){
+        if (self.isRecording){
+            self.endRecording()
+        } else {
+            self.startRecording()
         }
     }
     
     func getRecording()-> Array<Double>{
         return self.recordedAmplitude
+    }
+    
+    mutating func startRecording(){
+        self.isRecording = true
+        self.recordedAmplitude = [] // reset the stored recording
+    }
+    
+    mutating func endRecording(){
+        self.isRecording = false
+    }
+    
+    func getIsRecording()->Bool{
+        return self.isRecording
     }
 }
 

--- a/visualizer/Models/AudioRecording.swift
+++ b/visualizer/Models/AudioRecording.swift
@@ -1,0 +1,28 @@
+//
+//  RecordingBuffer.swift
+//  visualizer
+//
+//  Created by John Yeung on 7/7/2022.
+//
+// an object storing the user recorded audio data
+
+import Foundation
+
+struct AudioRecordings {
+    var recordedAmplitude: Array<Double> = [] // the stored Amplitudes
+    var timeCap: Int = -1 // the maximum size for the recorded amplitude, -1 means unlimited
+    
+    mutating func addAmplitude(lastAmplitude: Double)->Bool{ // return a boolean value to var isRecording, stop the recording if recordedAmplitude reached its max size
+        if (self.timeCap > 0 && self.recordedAmplitude.count < timeCap){
+            self.recordedAmplitude.append(lastAmplitude)
+            return true
+        } else{
+            return false
+        }
+    }
+    
+    func getRecording()-> Array<Double>{
+        return self.recordedAmplitude
+    }
+}
+


### PR DESCRIPTION
A structure storing the Recording information is created under Models, see details in the code file
```
struct AudioRecording {
    var recordedAmplitude: Array<Double> = [] // the stored Amplitudes
    var timeCap: Int = -1 // the maximum size for the recorded amplitude, -1 means unlimited
    var isRecording: Bool=false
    
    mutating func addAmplitude(lastAmplitude: Double)->Void{ 
        if (self.isRecording){
            if ((self.timeCap == -1) || (self.recordedAmplitude.count < timeCap)){
                self.recordedAmplitude.append(lastAmplitude)
            } else{ // if max size is reached, pause the recording.
                self.endRecording()
            }
        }
    }
    
    mutating func toggleRecording(){
        if (self.isRecording){
            self.endRecording()
        } else {
            self.startRecording()
        }
    }
```
the object is created in Audio, which's method is called in AudioViewModel
```
208 // update the last captured amplitude
209        self.audio.lastAmplitude = Double(amplitude[0])
210        self.audio.recording.addAmplitude(lastAmplitude: self.audio.lastAmplitude)
211            
212        self.updateReferenceTimbre()
213       self.updateIsPitchAccurate()
```

Currently, the recording can only be triggered if islive.
upon clicking the button, it turns red, clears the previous recording data and starts appending newly received lastAmpliture to audio.recording.recordedAmplitude (a get method is provided in the struct)

you can view the realtime length, attritube values of the object by uncomenting these code in SoundView.swift
```
                    CaptureTimeButton(
                        action: {
                            vm.audio.recording.toggleRecording()
                            
                        },
                        captureTime: vm.audio.captureTime,
                        isRecording: vm.audio.recording.isRecording)
//                    Text(String(vm.audio.recording.recordedAmplitude.count))
//                    Text(String(vm.audio.recording.isRecording))
//                    Text(String(vm.audio.recording.timeCap))
```

